### PR TITLE
fix: bump default fields

### DIFF
--- a/go/main.go
+++ b/go/main.go
@@ -192,7 +192,7 @@ func (g *Go) Gotestsum(
 	packages []string,
 	// Gotestsum format to display.
 	// +optional
-	// +default=testname
+	// +default="testname"
 	format string,
 	// Whether to run tests with race detection.
 	// +optional


### PR DESCRIPTION
Following Dagger's latest release 0.9.11, a breaking change was introducted that led the pkgs apko and go to not be runable

Before:
<img width="1386" alt="image" src="https://github.com/vito/daggerverse/assets/31691250/2d7ecf3e-ada4-4576-ba1c-32e31addd26e">

Now:
<img width="1002" alt="image" src="https://github.com/vito/daggerverse/assets/31691250/56443430-57fe-4d18-91ed-e204a7a44972">
