### PR TITLE
feat(compose): rename Env struct to EnvVar

### DIFF
--- a/docker/compose.go
+++ b/docker/compose.go
@@ -23,12 +23,12 @@ type Compose struct {
 	Files []string
 
 	// Environment variables to interpolate into the Compose config files.
-	Env []Env
+	Env []EnvVar
 }
 
-// Env represents an environment variable to interpolate into the Compose config
+// EnvVar represents an environment variable to interpolate into the Compose config
 // files.
-type Env struct {
+type EnvVar struct {
 	Name  string
 	Value string
 }
@@ -36,7 +36,7 @@ type Env struct {
 // WithEnv sets an environment variable that may be interpolated into the
 // Compose config files.
 func (m *Compose) WithEnv(name, val string) *Compose {
-	m.Env = append(m.Env, Env{
+	m.Env = append(m.Env, EnvVar{
 		Name:  name,
 		Value: val,
 	})


### PR DESCRIPTION
I encountered the following error when I attempted to upgrade dagger to 0.18.x due to a type name collision:

```
Error: failed to serve module: input: moduleSource.asModule failed to load dependencies as modules: failed to load module dependencies: select: failed to load dependencies as modules: failed to load module dependencies: select: failed to call module "docker" to get functions: call constructor: process "go build -ldflags -s -w -o /runtime ." did not complete successfully: exit code: 1

Stderr:
# main
./dagger.gen.go:348:6: Env redeclared in this block
        ./compose.go:29:6: other declaration of Env
```

@shykes explained to me that this was due to a naming collision with your docker module, being a transitive dependency of another module I was using (kpenfound/dagger-modules/proxy). Until dagger can implement more robust namespacing, I kindly ask you to rename the Env variable at your end.